### PR TITLE
Add CR0 register union and modify init_paging

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -1,0 +1,22 @@
+#include <stdint.h>
+
+union cr0 {
+    uint64_t control;
+    struct {
+        uint64_t pe : 1;
+        uint64_t mp : 1;
+        uint64_t em : 1;
+        uint64_t ts : 1;
+        uint64_t et : 1;
+        uint64_t ne : 1;
+        uint64_t reserved1 : 10;
+        uint64_t wp : 1;
+        uint64_t reserved2 : 1;
+        uint64_t am : 1;
+        uint64_t reserved3 : 10;
+        uint64_t nw : 1;
+        uint64_t cd : 1;
+        uint64_t pg : 1;
+        uint64_t reserved4 : 32;
+    } bits;
+};

--- a/src/paging.c
+++ b/src/paging.c
@@ -2,6 +2,7 @@
 #include "paging.h"
 #include "assembly.h"
 #include <stdalign.h>
+#include "cpu.h"
 
 #define PageSize4K 4096
 #define PageSize2M 512 * PageSize4K
@@ -20,8 +21,10 @@ void init_paging() {
         }
     }
 
+    union cr0 current_cr0 = (union cr0)read_cr0();
+    current_cr0.bits.wp = 1;
     write_cr3((uint64_t)&pml4_table[0]);
-    write_cr0(read_cr0() & 0xfffeffff);
+    write_cr0(current_cr0.control);
 }
 
 

--- a/src/paging.c
+++ b/src/paging.c
@@ -21,7 +21,8 @@ void init_paging() {
         }
     }
 
-    union cr0 current_cr0 = (union cr0)read_cr0();
+    union cr0 current_cr0;
+    current_cr0.control = read_cr0();
     current_cr0.bits.wp = 1;
     write_cr3((uint64_t)&pml4_table[0]);
     write_cr0(current_cr0.control);


### PR DESCRIPTION
制御レジスタ周りはビット操作が基本になると思うので、unionを使って扱いやすくできないかと考えた。
VMCS関連の処理もビット単位でread/writeする処理が多いので、unionは比較的多用することになるのでは、と考えている。
（と言ってもCに自信が全くないのでPRで留めておく・・・）